### PR TITLE
Integrate grommet

### DIFF
--- a/kit/views/ssr.js
+++ b/kit/views/ssr.js
@@ -17,7 +17,8 @@ const Html = ({ head, html, state, scripts, chunkManifest, css }) => (
       <meta httpEquiv="Content-Language" content="en" />
       <meta name="viewport" content="width=device-width, initial-scale=1" />
       {head.meta.toComponent()}
-      <link rel="stylesheet" href={css} />
+      <link rel="stylesheet" type="text/css" href="https://cdnjs.cloudflare.com/ajax/libs/grommet/1.3.4/grommet.min.css" />
+      <link rel="stylesheet" type="text/css" href={css} />
       {head.title.toComponent()}
       <script
         dangerouslySetInnerHTML={{

--- a/kit/views/webpack.html
+++ b/kit/views/webpack.html
@@ -5,6 +5,7 @@
     <meta httpEquiv="X-UA-Compatible" content="IE=edge" />
     <meta httpEquiv="Content-Language" content="en" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <link rel="stylesheet" type="text/css" href="https://cdnjs.cloudflare.com/ajax/libs/grommet/1.3.4/grommet.min.css">
     <title>ReactQL</title>
   </head>
   <body>

--- a/kit/webpack/browser_dev.js
+++ b/kit/webpack/browser_dev.js
@@ -31,6 +31,17 @@ const cssLoader = {
   },
 };
 
+const sassLoader = {
+  loader: 'sass-loader',
+  options: {
+    outputStyle: 'expanded',
+    includePaths: [
+      './node_modules',
+    ],
+    sourceMap: true,
+  },
+};
+
 export default new WebpackConfig().extend({
   '[root]/browser.js': conf => {
     // Add `webpack-dev-server` polyfills needed to communicate with the browser
@@ -125,7 +136,7 @@ export default new WebpackConfig().extend({
           'style-loader',
           cssLoader,
           'resolve-url-loader',
-          'sass-loader?sourceMap',
+          sassLoader,
         ],
       },
       // LESS processing.  Parsed through `less-loader` first

--- a/kit/webpack/browser_prod.js
+++ b/kit/webpack/browser_prod.js
@@ -59,6 +59,17 @@ const cssLoader = {
   },
 };
 
+// SASS/SCSS loader
+const sassLoader = {
+  loader: 'sass-loader',
+  options: {
+    outputStyle: 'compressed',
+    includePaths: [
+      './node_modules',
+    ],
+  },
+};
+
 // Extend the `browser.js` config
 export default new WebpackConfig().extend({
   '[root]/browser.js': config => {
@@ -108,7 +119,7 @@ export default new WebpackConfig().extend({
             cssLoader,
             'postcss-loader',
             'resolve-url-loader',
-            'sass-loader?sourceMap',
+            sassLoader,
           ],
           fallback: 'style-loader',
         }),

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "webpack-node-externals": "^1.5.4"
   },
   "dependencies": {
+    "grommet": "^1.3.4",
     "isomorphic-fetch": "^2.2.1",
     "koa": "^2.2.0",
     "koa-helmet": "^3.1.0",

--- a/src/app.js
+++ b/src/app.js
@@ -17,7 +17,13 @@ import Helmet from 'react-helmet';
 // Helper to merge expected React PropTypes to Apollo-enabled component
 import { mergeData } from 'kit/lib/apollo';
 
+import App from 'grommet/components/App';
+import Header from 'grommet/components/Header';
+import Footer from 'grommet/components/Footer';
+import Title from 'grommet/components/Title';
+
 // Styles
+import 'grommet/scss/vanilla/index.scss';
 import css from './styles.css';
 import sass from './styles.scss';
 import less from './styles.less';
@@ -91,7 +97,7 @@ class GraphQLMessage extends React.PureComponent {
         }),
       ),
     }),
-  }
+  };
 
   render() {
     const { data } = this.props;
@@ -146,5 +152,26 @@ export default () => (
     <hr />
     <p>Stylesheet examples:</p>
     <Styles />
+    <hr />
+    <App centered={false}>
+      <Header
+        direction="row"
+        justify="between"
+        size="large"
+        pad={{ horizontal: 'medium' }}>
+        <Title>Grommet</Title>
+      </Header>
+      <Footer
+        primary
+        appCentered
+        direction="column"
+        align="center"
+        pad="small"
+        colorIndex="grey-1">
+        <p>
+          Build your ideas with <a href="http://grommet.io" rel="noopener noreferrer" target="_blank">Grommet</a>!
+        </p>
+      </Footer>
+    </App>
   </div>
 );


### PR DESCRIPTION
So while both `dev` and `prod` compile, unlike the `devServer` which runs, `node dist/server` currently throws:
```
/Users/Bart/Dev/fuser/client/node_modules/grommet/scss/vanilla/index.scss:1
(function (exports, require, module, __filename, __dirname) { @import 'vanilla.defaults';
                                                              ^
SyntaxError: Invalid or unexpected token
    at createScript (vm.js:53:10)
    at Object.runInThisContext (vm.js:95:10)
    at Module._compile (module.js:543:28)
    at Object.Module._extensions..js (module.js:580:10)
    at Module.load (module.js:488:32)
    at tryModuleLoad (module.js:447:12)
    at Function.Module._load (module.js:439:3)
    at Module.require (module.js:498:17)
    at require (internal/module.js:20:19)
    at Object.<anonymous> (/Users/Bart/Dev/fuser/client/dist/server.js:1014:18)
```

I'm probably doing something wrong, but I've not been yet able to figure out what nor how to remedy it.