### PR TITLE
Added overlay to dev server

### DIFF
--- a/kit/webpack/browser_dev.js
+++ b/kit/webpack/browser_dev.js
@@ -78,6 +78,10 @@ export default new WebpackConfig().extend({
     // Disable build's information
     noInfo: false,
 
+    // Show a full-screen overlay in the browser when there is a
+    // compiler error
+    overlay: true,
+
     // We're using React Router for all routes, so redirect 404s
     // back to the webpack-dev-server bootstrap HTML
     historyApiFallback: {


### PR DESCRIPTION
Adds overlay to dev server showing compile errors in browser.

![screen shot 2017-04-24 at 5 50 54 pm](https://cloud.githubusercontent.com/assets/8162598/25361998/f4e0f408-2916-11e7-8b0e-2a9c61230feb.png)
