### PR TITLE
.editorconfig ESLint fix eol-last

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -4,6 +4,7 @@ end_of_line = lf
 indent_size = 2
 charset = utf-8
 trim_trailing_whitespace = true
+insert_final_newline = true
 
 [*.md]
 max_line_length = 0


### PR DESCRIPTION
Just small fix to `.editorconfig` file

Missing `insert_final_newline = true`