### PR TITLE
Enabled ModuleConcatenationPlugin

### DIFF
--- a/kit/webpack/browser_prod.js
+++ b/kit/webpack/browser_prod.js
@@ -171,6 +171,8 @@ export default new WebpackConfig().extend({
       openAnalyzer: BUNDLE_ANALYZER.openAnalyzer,
     }),
 
+    new webpack.optimize.ModuleConcatenationPlugin(),
+
     // Copy files from `PATHS.static` to `dist/public`.  No transformations
     // will be performed on the files-- they'll be copied as-is
     new CopyWebpackPlugin([


### PR DESCRIPTION
Webpack's 3 biggest feature, scope-hoisting, is enabled by the ModuleConcatenationPlugin. I've enabled this plugin in the `browser_prod` build which now decreases the vendor bundle by 14kb.