### PR TITLE
use correct config for external network interface

### DIFF
--- a/kit/entry/server.js
+++ b/kit/entry/server.js
@@ -107,7 +107,7 @@ const createNeworkInterface = (() => {
 
   function externalInterface() {
     return createNetworkInterface({
-      uri: config.apolloURI,
+      uri: config.graphQLEndpoint,
     });
   }
 


### PR DESCRIPTION
Trying to use external GraphQL server yields:
'Error A remote endpoint is required for a network layer Error: A remote endpoint is required for a network layer'
Caused by incorrect reference to config.apolloURI
