### PR TITLE
Configure graphiql IDE to use the graphQLEndpoint

### DIFF
--- a/kit/entry/server.js
+++ b/kit/entry/server.js
@@ -295,7 +295,7 @@ if (config.graphQLServer) {
     router.get(
       config.graphQLServer.endpoint,
       apolloGraphQLServer.graphiqlKoa({
-        endpointURL: config.graphQLEndpoint
+        endpointURL: config.graphQLEndpoint,
       }),
     );
   }

--- a/kit/entry/server.js
+++ b/kit/entry/server.js
@@ -295,7 +295,7 @@ if (config.graphQLServer) {
     router.get(
       config.graphQLServer.endpoint,
       apolloGraphQLServer.graphiqlKoa({
-        endpointURL: config.graphQLServer.endpoint,
+        endpointURL: config.graphQLEndpoint
       }),
     );
   }


### PR DESCRIPTION
I had assumed that when I set my `config.graphQLEndpoint` via `config.setGraphQLEndpoint()` that the graphiql IDE would continue to be served at `/graphql` and instead connect to my configured `graphQLEndpoint`. 

Upon further examination, it seems the only way the graphiql IDE works is if:

```
config.graphQLEndpoint === config.graphQLServer.endpoint
```

This PR attempts to address that. 

Unfortunately, even with this fix the graphql server is still served at `POST ${config.graphQLServer.endpoint}` despite the modified `graphQLEndpoint`. 


Aside: This kit has drastically reduced the react/redux/graphql learning curve for me - at least it feels that way based on my past intimidation/procrastination. I'm overwhelmingly appreciative of the effort that's gone into it. Thank you!