### PR TITLE
Make Dockerfile more efficient for caching and add yarn

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM debian:testing-slim
 
-ENV EPHIMERAL_PACKAGES "build-essential dh-autoreconf curl xz-utils python git"
+ENV EPHIMERAL_PACKAGES "build-essential dh-autoreconf curl xz-utils python"
 ENV PACKAGES "libpng-dev git"
 
 # Install apt packages (and clean up afterwards)

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,21 +1,26 @@
-FROM debian:jessie-slim
+FROM debian:testing-slim
 
-ENV EPHIMERAL_PACKAGES "build-essential dh-autoreconf curl xz-utils python"
-ENV PACKAGES "libpng-dev"
+ENV EPHIMERAL_PACKAGES "build-essential dh-autoreconf curl xz-utils python git"
+ENV PACKAGES "libpng-dev git"
 
-# Add `package.json` to build Debian compatible NPM packages
-WORKDIR /src
-ADD package.json .
-
-# install everything (and clean up afterwards)
+# Install apt packages (and clean up afterwards)
 RUN apt-get update \
   && apt-get install -y apt-utils \
   && apt-get install -y ${EPHIMERAL_PACKAGES} ${PACKAGES} \
   && curl -sL https://deb.nodesource.com/setup_8.x | bash - \
-  && apt-get install -y nodejs \
-  && cd /src \
-  && npm i \
-  ; apt-get remove --purge -y ${EPHIMERAL_PACKAGES} \
+  && apt-get install -y nodejs
+
+# Install app dependencies
+WORKDIR /tmp
+COPY package.json /tmp/
+RUN npm config set registry http://registry.npmjs.org/
+
+# Install yarn for dev and faster builds
+RUN npm i -g yarn
+RUN yarn install
+
+# Clean up apt packages not needed
+RUN apt-get remove --purge -y ${EPHIMERAL_PACKAGES} \
   ; apt-get autoremove -y ${EPHIMERAL_PACKAGES} \
   ; apt-get clean \
   ; apt-get autoclean \
@@ -24,15 +29,21 @@ RUN apt-get update \
   ; rm -rf /usr/share/man/?? \
   ; rm -rf /usr/share/man/??_*
 
-# Add the remaining project files
-ADD . .
+# Create app directory
+RUN mkdir -p /usr/src/app
+WORKDIR /usr/src/app
+
+# Bundle app source
+COPY . /usr/src/app
+RUN cp -a /tmp/node_modules /usr/src/app/
 
 # Build distribution
-RUN npm run build
+RUN yarn run clean && yarn run build
 
 # Set the default host/port
 ENV HOST 0.0.0.0
 ENV PORT 4000
+EXPOSE 4000
 
 # Start the server by default
 CMD npm run server


### PR DESCRIPTION
I've updated the Dockerfile to split up package installation and removal, as well as decreasing build times, by having npm install cached separately, then copied over. This Dockerfile allows docker-compose to work more efficiently as well. I installed yarn for increased speed and also to allow development work to take place if using `docker run -it` for example.