### PR TITLE
Add support for OpenType fonts

### DIFF
--- a/kit/webpack/common.js
+++ b/kit/webpack/common.js
@@ -15,7 +15,7 @@ import chalk from 'chalk';
 
 // RegExp for file types
 export const regex = {
-  fonts: /\.(woff|woff2|ttf|eot)$/i,
+  fonts: /\.(woff|woff2|(o|t)tf|eot)$/i,
   images: /\.(jpe?g|png|gif|svg)$/i,
 };
 


### PR DESCRIPTION
This commit amends the regex in common.js so that webpack may resolve OpenType fonts with file-loader.