### PR TITLE
Update Dockerfile to fix zopfli compilation error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM debian:jessie-slim
 
-ENV EPHIMERAL_PACKAGES "build-essential dh-autoreconf curl xz-utils python"
+ENV EPHIMERAL_PACKAGES "build-essential dh-autoreconf curl xz-utils python binutils"
 ENV PACKAGES "libpng-dev"
 
 # Add `package.json` to build Debian compatible NPM packages


### PR DESCRIPTION
Added  binutils to prevent error with compiling zopfli "g++: error trying to exec 'as': execvp: No such file or directory"