### PR TITLE
Include <link>s from Helmet in SSR output.

### DIFF
--- a/kit/views/ssr.js
+++ b/kit/views/ssr.js
@@ -19,6 +19,7 @@ const Html = ({ head, scripts, window, css, children }) => (
       {head.meta.toComponent()}
       <link rel="stylesheet" href={css} />
       {head.title.toComponent()}
+      {head.link.toComponent()}
     </head>
     <body>
       <div id="main">{children}</div>


### PR DESCRIPTION
This seems to have been an oversight, unless there is something I'm missing.