### PR TITLE
Optimize Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,34 +1,9 @@
-FROM debian:jessie-slim
+FROM node:8-alpine
 
-ENV EPHIMERAL_PACKAGES "build-essential dh-autoreconf curl xz-utils python binutils"
-ENV PACKAGES "libpng-dev"
-
-# Add `package.json` to build Debian compatible NPM packages
 WORKDIR /src
-ADD package.json .
 
-# install everything (and clean up afterwards)
-RUN apt-get update \
-  && apt-get install -y apt-utils \
-  && apt-get install -y ${EPHIMERAL_PACKAGES} ${PACKAGES} \
-  && curl -sL https://deb.nodesource.com/setup_8.x | bash - \
-  && apt-get install -y nodejs \
-  && cd /src \
-  && npm i \
-  ; apt-get remove --purge -y ${EPHIMERAL_PACKAGES} \
-  ; apt-get autoremove -y ${EPHIMERAL_PACKAGES} \
-  ; apt-get clean \
-  ; apt-get autoclean \
-  ; echo -n > /var/lib/apt/extended_states \
-  ; rm -rf /var/lib/apt/lists/* \
-  ; rm -rf /usr/share/man/?? \
-  ; rm -rf /usr/share/man/??_*
-
-# Add the remaining project files
-ADD . .
-
-# Build distribution
-RUN npm run build
+# The official image has verbose logging; change it to npm's default
+ENV NPM_CONFIG_LOGLEVEL notice
 
 # Set the default host/port
 ENV HOST 0.0.0.0
@@ -36,3 +11,24 @@ ENV PORT 4000
 
 # Start the server by default
 CMD npm run server
+
+ADD package.json package-lock.json ./
+
+# Install everything (and clean up afterwards)
+RUN apk add --no-cache --virtual .gyp \
+    autoconf \
+    automake \
+    g++ \
+    libpng-dev \
+    libtool \
+    make \
+    nasm \
+    python \
+  && npm install \
+  && apk del .gyp
+
+# Add the remaining project files
+ADD . .
+
+# Build distribution
+RUN npm run build


### PR DESCRIPTION
Switch to Node/Alpine base image instead of Debian - makes for a much smaller Docker image.

Also add `package-lock.json` to the build and optimize order of commands for a quicker build.