### PR TITLE
New feature: Add in scope environment variables in ENV_VARIABLES

### DIFF
--- a/kit/webpack/common.js
+++ b/kit/webpack/common.js
@@ -189,3 +189,14 @@ export function webpackProgress(what = chalk.magenta.bold('ReactQL')) {
     format: `${what} building [:bar] ${chalk.green.bold(':percent')} (:elapsed seconds)`,
   });
 }
+
+
+export function getInscopeEnvVariables() {
+  const env = {};
+  const ENV_VARIABLES = process.env.ENV_VARIABLES;
+  const envVariables = ENV_VARIABLES ? ENV_VARIABLES.split(/[ :]+/) : [];
+  envVariables.forEach(k => {
+    env[k] = JSON.stringify(process.env[k]);
+  });
+  return env;
+}

--- a/kit/webpack/common.js
+++ b/kit/webpack/common.js
@@ -191,11 +191,9 @@ export function webpackProgress(what = chalk.magenta.bold('ReactQL')) {
 }
 
 
-export function getInscopeEnvVariables() {
+export function getEnvVariables() {
   const env = {};
-  const ENV_VARIABLES = process.env.ENV_VARIABLES;
-  const envVariables = ENV_VARIABLES ? ENV_VARIABLES.split(/[ :]+/) : [];
-  envVariables.forEach(k => {
+  Object.keys(process.env).forEach(k => {
     env[k] = JSON.stringify(process.env[k]);
   });
   return env;

--- a/kit/webpack/server_dev.js
+++ b/kit/webpack/server_dev.js
@@ -27,7 +27,7 @@ import ExtractTextPlugin from 'extract-text-webpack-plugin';
 import CopyWebpackPlugin from 'copy-webpack-plugin';
 
 /* Local */
-import { css } from './common';
+import { css, getInscopeEnvVariables } from './common';
 import PATHS from '../../config/paths';
 
 // ----------------------
@@ -75,7 +75,7 @@ export default [
       new webpack.DefinePlugin({
         // We ARE running on the server
         SERVER: true,
-        'process.env': {
+        'process.env': Object.assign(getInscopeEnvVariables(), {
           // Point the server host/port to the production server
           HOST: JSON.stringify(process.env.HOST || 'localhost'),
           PORT: JSON.stringify(process.env.PORT || '8081'),
@@ -84,7 +84,7 @@ export default [
           // Debug development
           NODE_ENV: JSON.stringify('development'),
           DEBUG: true,
-        },
+        }),
       }),
 
       // Start the development server
@@ -112,7 +112,7 @@ export default [
       new webpack.DefinePlugin({
         // We're not running on the server
         SERVER: false,
-        'process.env': {
+        'process.env': Object.assign(getInscopeEnvVariables(), {
           // Point the server host/port to the dev server
           HOST: JSON.stringify(process.env.HOST || 'localhost'),
           PORT: JSON.stringify(process.env.PORT || '8081'),
@@ -121,7 +121,7 @@ export default [
           // Debug development
           NODE_ENV: JSON.stringify('development'),
           DEBUG: true,
-        },
+        }),
       }),
 
       // Check for errors, and refuse to emit anything with issues

--- a/kit/webpack/server_dev.js
+++ b/kit/webpack/server_dev.js
@@ -27,7 +27,7 @@ import ExtractTextPlugin from 'extract-text-webpack-plugin';
 import CopyWebpackPlugin from 'copy-webpack-plugin';
 
 /* Local */
-import { css, getInscopeEnvVariables } from './common';
+import { css, getEnvVariables } from './common';
 import PATHS from '../../config/paths';
 
 // ----------------------
@@ -75,16 +75,17 @@ export default [
       new webpack.DefinePlugin({
         // We ARE running on the server
         SERVER: true,
-        'process.env': Object.assign(getInscopeEnvVariables(), {
+        'process.env': Object.assign({
           // Point the server host/port to the production server
-          HOST: JSON.stringify(process.env.HOST || 'localhost'),
-          PORT: JSON.stringify(process.env.PORT || '8081'),
-          SSL_PORT: process.env.SSL_PORT ? JSON.stringify(process.env.SSL_PORT) : null,
+          HOST: JSON.stringify('localhost'),
+          PORT: JSON.stringify('8081'),
+          SSL_PORT: null,
 
           // Debug development
           NODE_ENV: JSON.stringify('development'),
           DEBUG: true,
-        }),
+        },
+        getEnvVariables()),
       }),
 
       // Start the development server
@@ -112,16 +113,16 @@ export default [
       new webpack.DefinePlugin({
         // We're not running on the server
         SERVER: false,
-        'process.env': Object.assign(getInscopeEnvVariables(), {
+        'process.env': Object.assign({
           // Point the server host/port to the dev server
-          HOST: JSON.stringify(process.env.HOST || 'localhost'),
-          PORT: JSON.stringify(process.env.PORT || '8081'),
-          SSL_PORT: process.env.SSL_PORT ? JSON.stringify(process.env.SSL_PORT) : null,
+          HOST: JSON.stringify('localhost'),
+          PORT: JSON.stringify('8080'),
+          SSL_PORT: null,
 
           // Debug development
           NODE_ENV: JSON.stringify('development'),
           DEBUG: true,
-        }),
+        }, getEnvVariables(),),
       }),
 
       // Check for errors, and refuse to emit anything with issues

--- a/kit/webpack/server_prod.js
+++ b/kit/webpack/server_prod.js
@@ -16,7 +16,7 @@ import WebpackConfig from 'webpack-config';
 import chalk from 'chalk';
 
 /* Local */
-import { webpackProgress } from './common';
+import { webpackProgress, getInscopeEnvVariables } from './common';
 import PATHS from '../../config/paths';
 
 // ----------------------
@@ -60,7 +60,7 @@ export default new WebpackConfig().extend({
     new webpack.DefinePlugin({
       // We ARE running on the server
       SERVER: true,
-      'process.env': {
+      'process.env': Object.assign(getInscopeEnvVariables(), {
         // Point the server host/port to the dev server
         HOST: JSON.stringify(process.env.HOST || 'localhost'),
         PORT: JSON.stringify(process.env.PORT || '4000'),
@@ -72,7 +72,7 @@ export default new WebpackConfig().extend({
         // a minifier to remove all of React's warnings in production.
         NODE_ENV: JSON.stringify('production'),
         DEBUG: false,
-      },
+      }),
     }),
   ],
 });

--- a/kit/webpack/server_prod.js
+++ b/kit/webpack/server_prod.js
@@ -16,7 +16,7 @@ import WebpackConfig from 'webpack-config';
 import chalk from 'chalk';
 
 /* Local */
-import { webpackProgress, getInscopeEnvVariables } from './common';
+import { webpackProgress, getEnvVariables } from './common';
 import PATHS from '../../config/paths';
 
 // ----------------------
@@ -60,11 +60,11 @@ export default new WebpackConfig().extend({
     new webpack.DefinePlugin({
       // We ARE running on the server
       SERVER: true,
-      'process.env': Object.assign(getInscopeEnvVariables(), {
+      'process.env': Object.assign({
         // Point the server host/port to the dev server
-        HOST: JSON.stringify(process.env.HOST || 'localhost'),
-        PORT: JSON.stringify(process.env.PORT || '4000'),
-        SSL_PORT: process.env.SSL_PORT ? JSON.stringify(process.env.SSL_PORT) : null,
+        HOST: JSON.stringify('localhost'),
+        PORT: JSON.stringify('4000'),
+        SSL_PORT: null,
 
         // React constantly checking process.env.NODE_ENV causes massive
         // slowdowns during rendering. Replacing process.env.NODE_ENV
@@ -72,7 +72,7 @@ export default new WebpackConfig().extend({
         // a minifier to remove all of React's warnings in production.
         NODE_ENV: JSON.stringify('production'),
         DEBUG: false,
-      }),
+      }, getEnvVariables()),
     }),
   ],
 });


### PR DESCRIPTION
## Purpose
Enable kit users to add environment variables to the scope of express' process.env. By default, the kit, only takes HOST, PORT, SSL_PORT, NODE_ENV and DEBUG into account.
This will enable users to define their environments' key values in their config files (e.g., Dockerfile, app.yaml for GAE).

## Approach
Users will add a list of environment variable names to be taken into account in the ENV_VARIABLES environment variable using the following template: VAR1:VAR2:VAR3...

#### Open Questions and Pre-Merge TODOs
- [x] Do we need to add the environment variables to browser_dev.js or browser_prod.js. If so, why?
