### PR TITLE
Webpack DLL

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,7 @@ jspm_packages
 
 # Distribution
 dist
+
+# Webpack DLL
+kit/webpack/dll.json
+static/vendor.js

--- a/kit/webpack/base.js
+++ b/kit/webpack/base.js
@@ -28,8 +28,6 @@ import PATHS from '../../config/paths';
 
 // ----------------------
 
-// RegExp for image files
-
 
 // Export a new 'base' config, which we can extend/merge from
 export default new WebpackConfig().merge({

--- a/kit/webpack/browser.js
+++ b/kit/webpack/browser.js
@@ -79,16 +79,4 @@ export default new WebpackConfig().extend('[root]/base.js').merge({
       },
     ],
   },
-
-  plugins: [
-    // Separate our third-party/vendor modules into a separate chunk, so that
-    // we can load them independently of our app-specific code changes
-    new webpack.optimize.CommonsChunkPlugin({
-      name: 'vendor',
-      minChunks: module => (
-        // this assumes your vendor imports exist in the node_modules directory
-        module.context && module.context.indexOf('node_modules') !== -1
-      ),
-    }),
-  ],
 });

--- a/kit/webpack/browser_dev.js
+++ b/kit/webpack/browser_dev.js
@@ -22,6 +22,9 @@ import { logServerStarted } from '../lib/console';
 // Local paths
 import PATHS from '../../config/paths';
 
+// Webpack DLL
+import manifest from './dll.json';
+
 // ----------------------
 
 // Host and port settings to spawn the dev server on
@@ -44,6 +47,11 @@ export default new WebpackConfig().extend({
       .use.unshift({
         loader: 'react-hot-loader/webpack',
       });
+
+    conf.plugins.push(new webpack.DllReferencePlugin({
+      name: 'dll',
+      manifest,
+    }));
 
     return conf;
   },

--- a/kit/webpack/browser_prod.js
+++ b/kit/webpack/browser_prod.js
@@ -93,6 +93,16 @@ export default new WebpackConfig().extend({
       `${chalk.magenta.bold('ReactQL browser bundle')} in ${chalk.bgMagenta.white.bold('production mode')}`,
     ),
 
+    // Separate our third-party/vendor modules into a separate chunk, so that
+    // we can load them independently of our app-specific code changes
+    new webpack.optimize.CommonsChunkPlugin({
+      name: 'vendor',
+      minChunks: module => (
+        // this assumes your vendor imports exist in the node_modules directory
+        module.context && module.context.indexOf('node_modules') !== -1
+      ),
+    }),
+
     // Global variables
     new webpack.DefinePlugin({
       // We're not running on the server

--- a/kit/webpack/dll.js
+++ b/kit/webpack/dll.js
@@ -1,0 +1,35 @@
+import { DllPlugin } from 'webpack';
+import WebpackConfig from 'webpack-config';
+
+// Local paths
+import PATHS from '../../config/paths';
+
+export default {
+  entry: [
+    // The more modules listed here the faster recompiling will be
+    // Use the webpack bundle analyzer to determine the largest modules
+    'apollo-client',
+    'graphql',
+    'history',
+    'lodash',
+    'prop-types',
+    'react-redux',
+    'react',
+    'react-apollo',
+    'react-dom',
+    'react-router-dom',
+    'redux',
+    'seamless-immutable',
+  ],
+  output: {
+    library: 'dll',
+    path: PATHS.static,
+    filename: 'vendor.js',
+  },
+  plugins: [
+    new DllPlugin({
+      name: 'dll',
+      path: `${PATHS.webpack}/dll.json`,
+    }),
+  ],
+};

--- a/package.json
+++ b/package.json
@@ -5,10 +5,11 @@
   "license": "UNLICENSED",
   "private": true,
   "scripts": {
-    "browser": "cross-env NODE_ENV=development WEBPACK_CONFIG=browser_dev webpack-dev-server --open",
+    "browser": "npm run build-dll && cross-env NODE_ENV=development WEBPACK_CONFIG=browser_dev webpack-dev-server --open",
     "build": "cross-env NODE_ENV=production WEBPACK_CONFIG=browser_prod,server_prod webpack --colors",
     "build-analyze": "cross-env BUNDLE_ANALYZER=1 NODE_ENV=production WEBPACK_CONFIG=browser_prod,server_prod webpack --colors",
     "build-browser": "cross-env NODE_ENV=production WEBPACK_CONFIG=browser_prod webpack --colors",
+    "build-dll": "cross-env NODE_ENV=development WEBPACK_CONFIG=dll webpack --colors",
     "build-run": "npm run build && npm run server",
     "build-static": "cross-env NODE_ENV=production WEBPACK_CONFIG=static webpack --colors",
     "build-static-run": "npm run build-static && npm run static",


### PR DESCRIPTION
This massively speeds up recompiling and hot reloading.

~~The only downside is the DLL must be built before starting the webpack dev server for the first time, and again after updating installed modules.~~

~~Use `npm run build-dll` to build it.~~

The initial list of modules included in the DLL is based on the largest modules in the browser bundle according to the output of the Webpack bundle analysis. Feel free to adjust it.