### PR TITLE
fix jest config file extension patterns

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,9 +1,9 @@
 module.exports = {
   coverageReporters: ['text'],
   collectCoverageFrom: [
-    'src/**/*.js(x)',
+    'src/**/*.{js,jsx}',
   ],
   transform: {
-    '^.+\\.js(x)$': '<rootDir>/jest.transform.js',
+    '^.+\\.jsx?$': '<rootDir>/jest.transform.js',
   },
 };


### PR DESCRIPTION
Current jest config is not matching .js files.  This change fixes that.