### PR TITLE
Fix for #121

### DIFF
--- a/kit/views/ssr.js
+++ b/kit/views/ssr.js
@@ -9,6 +9,8 @@ import PropTypes from 'prop-types';
 
 // ----------------------
 
+const idPrefix = 'REACTQL.';
+
 const Html = ({ helmet, scripts, window, css, children }) => (
   <html lang="en" prefix="og: http://ogp.me/ns#" {...helmet.htmlAttributes.toString()}>
     <head>
@@ -27,10 +29,20 @@ const Html = ({ helmet, scripts, window, css, children }) => (
     </head>
     <body {...helmet.bodyAttributes.toComponent()}>
       <div id="main">{children}</div>
+      {Object.keys(window).map(key => (
+        <script
+          key={key}
+          type="application/json"
+          id={`${idPrefix}${key}`}
+          dangerouslySetInnerHTML={{
+            __html: JSON.stringify(window[key]),
+          }} />
+      ))}
       <script
         dangerouslySetInnerHTML={{
           __html: Object.keys(window).reduce(
-            (out, key) => out += `window.${key}=${JSON.stringify(window[key])};`,
+            (out, key) =>
+              (out += `window['${key}'] = JSON.parse(document.getElementById('${idPrefix}${key}').innerHTML);`),
             '',
           ),
         }} />


### PR DESCRIPTION
This is the proof of concept fix for #121

I want to collect some feedback with regards to the element id namespacing and the general approach to access these JSON blobs. `document.getElementById().innerHTML` is used here but there are many options to select them(ids, classes, data attributes).

I'd also like to talk about line 45 and its surroundings now, which is pretty dirty. Doing what is basically abstracted `eval`'ing(but I didn't want to include this change immediately):
```js
(out += `window['${key}'] = JSON.parse(document.getElementById('${idPrefix}${key}').innerHTML);`)
```

My suggestion is to replace this script tag with another JSON blob containing our keys and moving all the window rehydration logic over into `kit/entry/browser.js`, check out my approach to that over at https://github.com/klarstrup/kit/compare/json-window...klarstrup:json-window-clean?expand=1 and tell me what you think.