### PR TITLE
Properly pass helmet html attributes when rendering on the server

### DIFF
--- a/kit/views/ssr.js
+++ b/kit/views/ssr.js
@@ -10,7 +10,7 @@ import PropTypes from 'prop-types';
 // ----------------------
 
 const Html = ({ helmet, scripts, window, css, children }) => (
-  <html lang="en" prefix="og: http://ogp.me/ns#" {...helmet.htmlAttributes.toString()}>
+  <html lang="en" prefix="og: http://ogp.me/ns#" {...helmet.htmlAttributes.toComponent()}>
     <head>
       {helmet.title.toComponent()}
       <meta charSet="utf-8" />


### PR DESCRIPTION
When spreading `helment.htmlAttributes.toString()`, it results in passing each letter as a prop.
E.g.
```html
<Helmet>
  <html lang="de" />
</Helmet>
``` 
turns into 
```html
<html 0="l" 1="a" 2="n" 3="g" 4="=" 5="&quot;" 6="d" 7="e" 8="&quot;" lang="en" prefix="og: http://ogp.me/ns#" data-reactroot="">
```