### PR TITLE
correct regex and glob so that .js and .jsx are correctly transformed

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,9 +1,10 @@
 module.exports = {
   coverageReporters: ['text'],
+  collectCoverage: true,
   collectCoverageFrom: [
-    'src/**/*.js(x)',
+    'src/**/*.{js,jsx}',
   ],
   transform: {
-    '^.+\\.js(x)$': '<rootDir>/jest.transform.js',
+    '^.+\\.jsx?$': '<rootDir>/jest.transform.js',
   },
 };


### PR DESCRIPTION
Fixes the regex issue where `.js` files are not correctly transformed in jest, meaning you couldn't previously use es6 imports in `.js` files during testing.

Fixes #133 & https://github.com/reactql/cli/issues/96