### PR TITLE
Use webpack's EnvironmentPlugin for env variables

### DIFF
--- a/kit/webpack/browser_dev.js
+++ b/kit/webpack/browser_dev.js
@@ -133,20 +133,20 @@ export default new WebpackConfig().extend({
     // Activate the hot-reloader, so changes can be pushed to the browser
     new webpack.HotModuleReplacementPlugin(),
 
+    // Replace environment variables at compile time.
+    new webpack.EnvironmentPlugin({
+      HOST: 'localhost',
+      PORT: '8081',
+      SSL_PORT: null,
+      // Debug development
+      NODE_ENV: 'development',
+      DEBUG: true,
+    }),
+
     // Global variables
     new webpack.DefinePlugin({
       // We're not running on the server
       SERVER: false,
-      'process.env': {
-        // Point the server host/port to the dev server
-        HOST: JSON.stringify(process.env.HOST || 'localhost'),
-        PORT: JSON.stringify(process.env.PORT || '8081'),
-        SSL_PORT: process.env.SSL_PORT ? JSON.stringify(process.env.SSL_PORT) : null,
-
-        // Debug development
-        NODE_ENV: JSON.stringify('development'),
-        DEBUG: true,
-      },
     }),
   ],
 });

--- a/kit/webpack/browser_prod.js
+++ b/kit/webpack/browser_prod.js
@@ -93,20 +93,19 @@ export default new WebpackConfig().extend({
       `${chalk.magenta.bold('ReactQL browser bundle')} in ${chalk.bgMagenta.white.bold('production mode')}`,
     ),
 
+    // Replace environment variables at compile time.
+    new webpack.EnvironmentPlugin({
+      HOST: 'localhost',
+      PORT: '4000',
+      SSL_PORT: null,
+      NODE_ENV: 'production',
+      DEBUG: false,
+    }),
+
     // Global variables
     new webpack.DefinePlugin({
       // We're not running on the server
       SERVER: false,
-      'process.env': {
-        // Point the server host/port to the production server
-        HOST: JSON.stringify(process.env.HOST || 'localhost'),
-        PORT: JSON.stringify(process.env.PORT || '4000'),
-        SSL_PORT: process.env.SSL_PORT ? JSON.stringify(process.env.SSL_PORT) : null,
-
-        // Optimise React, etc
-        NODE_ENV: JSON.stringify('production'),
-        DEBUG: false,
-      },
     }),
 
     // Check for errors, and refuse to emit anything with issues

--- a/kit/webpack/server_dev.js
+++ b/kit/webpack/server_dev.js
@@ -72,19 +72,19 @@ export default [
     },
 
     plugins: [
+      // Replace environment variables at compile time.
+      new webpack.EnvironmentPlugin({
+        HOST: 'localhost',
+        PORT: '8081',
+        SSL_PORT: null,
+        // Debug development
+        NODE_ENV: 'development',
+        DEBUG: true,
+      }),
+
       new webpack.DefinePlugin({
         // We ARE running on the server
         SERVER: true,
-        'process.env': {
-          // Point the server host/port to the production server
-          HOST: JSON.stringify(process.env.HOST || 'localhost'),
-          PORT: JSON.stringify(process.env.PORT || '8081'),
-          SSL_PORT: process.env.SSL_PORT ? JSON.stringify(process.env.SSL_PORT) : null,
-
-          // Debug development
-          NODE_ENV: JSON.stringify('development'),
-          DEBUG: true,
-        },
       }),
 
       // Start the development server
@@ -109,19 +109,19 @@ export default [
       ],
     },
     plugins: [
+      // Replace environment variables at compile time.
+      new webpack.EnvironmentPlugin({
+        HOST: 'localhost',
+        PORT: '8081',
+        SSL_PORT: null,
+        // Debug development
+        NODE_ENV: 'development',
+        DEBUG: true,
+      }),
+
       new webpack.DefinePlugin({
         // We're not running on the server
         SERVER: false,
-        'process.env': {
-          // Point the server host/port to the dev server
-          HOST: JSON.stringify(process.env.HOST || 'localhost'),
-          PORT: JSON.stringify(process.env.PORT || '8081'),
-          SSL_PORT: process.env.SSL_PORT ? JSON.stringify(process.env.SSL_PORT) : null,
-
-          // Debug development
-          NODE_ENV: JSON.stringify('development'),
-          DEBUG: true,
-        },
       }),
 
       // Check for errors, and refuse to emit anything with issues

--- a/kit/webpack/server_prod.js
+++ b/kit/webpack/server_prod.js
@@ -56,23 +56,23 @@ export default new WebpackConfig().extend({
       `${chalk.magenta.bold('ReactQL server bundle')} in ${chalk.bgMagenta.white.bold('production mode')}`,
     ),
 
+    // Replace environment variables at compile time.
+    new webpack.EnvironmentPlugin({
+      HOST: 'localhost',
+      PORT: '4000',
+      SSL_PORT: null,
+      // React constantly checking process.env.NODE_ENV causes massive
+      // slowdowns during rendering. Replacing process.env.NODE_ENV
+      // with a string not only removes this expensive check, it allows
+      // a minifier to remove all of React's warnings in production.
+      NODE_ENV: 'production',
+      DEBUG: false,
+    }),
+
     // Global variables
     new webpack.DefinePlugin({
       // We ARE running on the server
       SERVER: true,
-      'process.env': {
-        // Point the server host/port to the dev server
-        HOST: JSON.stringify(process.env.HOST || 'localhost'),
-        PORT: JSON.stringify(process.env.PORT || '4000'),
-        SSL_PORT: process.env.SSL_PORT ? JSON.stringify(process.env.SSL_PORT) : null,
-
-        // React constantly checking process.env.NODE_ENV causes massive
-        // slowdowns during rendering. Replacing process.env.NODE_ENV
-        // with a string not only removes this expensive check, it allows
-        // a minifier to remove all of React's warnings in production.
-        NODE_ENV: JSON.stringify('production'),
-        DEBUG: false,
-      },
     }),
   ],
 });


### PR DESCRIPTION
When set up this way (`'process.env': {...}`), Webpack's [DefinePlugin](https://webpack.js.org/plugins/define-plugin/) will override any use of `process.env` at build time.
Instead, the [EnvironmentPlugin](https://webpack.js.org/plugins/environment-plugin/), will only replace the env variables you care about, leaving room for other env variables to be used at run time.
  